### PR TITLE
Task: Fallbacks and Transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 
     <title>crypTones</title>
   </head>
-  <body>
+      <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@testing-library/user-event": "14.1.1",
     "@tonaljs/tonal": "^4.6.5",
     "@types/jest": "27.4.1",
-    "@types/react": "18.0.8",
+    "@types/react": "18.0.9",
     "@types/react-dom": "18.0.3",
     "@types/styled-components": "5.1.25",
     "@typescript-eslint/eslint-plugin": "5.19.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ export function App() {
       <ModeProvider>
         <CssBaseline>
           <NavBar />
-          <Modal isOpen={true} />
+          <Modal isOpen={false} />
           <Display />
         </CssBaseline>
       </ModeProvider>

--- a/src/components/err-and-feedback/ErrorFallback.tsx
+++ b/src/components/err-and-feedback/ErrorFallback.tsx
@@ -1,15 +1,33 @@
+import React from 'react'
+
 type Props = {
-  error: any
+  error?: any
   resetErrorBoundary?: any
 }
 
 //TODO: Customize ErrorFallback, classify possible errors (Took too long, API reject, not found, other) and conditionally render a retry option vs "play around with historical data"
-export default function ErrorFallback({ error, resetErrorBoundary }: Props) {
+/**
+ * rendered when child of ErrorBoundary throws error.
+ * resetErrorBoundary triggers function called with onReset in ErrorBoundary component that rendered the fallback.
+ *   @todo customizing this component further at this juncture feels a little bit like bedazzling a life-jacket, but is likely worth adding to the chore stack.
+ * @params error: error caught by ErrorBoundary
+ * @returns
+ */
+export default function ErrorFallback({
+  error,
+  resetErrorBoundary,
+}: Props): React.ReactElement<unknown, string | React.FunctionComponent> {
   return (
     <div role="alert">
       <p>Something went wrong:</p>
-      <pre>{error.message}</pre>
+      {error ? <pre>{error.message}</pre> : null}
       <button onClick={resetErrorBoundary}>Try again</button>
+      <p>
+        {' '}
+        if this issue persists, please consider sending an email to
+        jordan@jmwalsh.dev or opening an issue at
+      </p>{' '}
+      <a href="https://github.com/jmwalsh91/cryptones/issues" />
     </div>
   )
 }

--- a/src/components/err-and-feedback/MappingsFallback.tsx
+++ b/src/components/err-and-feedback/MappingsFallback.tsx
@@ -1,0 +1,31 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react'
+import { Paper } from '@mui/material'
+
+import { useMode } from '~/utils/hooks/useMode'
+
+import * as base from '../../styles/base'
+
+function MappingsFallback() {
+  const themedNeu = useMode()
+  return (
+    <>
+      <Paper
+        css={css`
+          ${themedNeu.depressed};
+          ${base.mapCard};
+        `}
+        sx={{
+          width: '100%',
+          height: '100%',
+          justifyContent: 'center',
+          px: '1rem',
+        }}
+      >
+        <p>loading</p>
+      </Paper>
+    </>
+  )
+}
+
+export default MappingsFallback

--- a/src/components/layout/MdLayout.tsx
+++ b/src/components/layout/MdLayout.tsx
@@ -20,9 +20,11 @@ function MdLayout() {
             <FullWidthCard />
           </Grid>
           <Grid item xs={12} sm={12} md={8}>
-            <Suspense fallback={<MappingsFallback />}>
-              <MappingsCard />
-            </Suspense>
+            <ErrorBoundary FallbackComponent={ErrorFallback}>
+              <Suspense fallback={<MappingsFallback />}>
+                <MappingsCard />
+              </Suspense>
+            </ErrorBoundary>
           </Grid>
           <Grid item xs={12} sm={12} md={4}>
             <ErrorBoundary FallbackComponent={ErrorFallback}>

--- a/src/components/layout/MdLayout.tsx
+++ b/src/components/layout/MdLayout.tsx
@@ -1,5 +1,5 @@
 import { Container, Grid } from '@mui/material'
-import { Suspense, useTransition } from 'react'
+import { Suspense, useState, useTransition } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
 import ToneContextWrapper from '../../services/ToneContextWrapper'
@@ -10,6 +10,11 @@ import MappingsCard from '../main-view/map/MappingsCard'
 import ToneCard from '../main-view/tone/ToneCard'
 
 function MdLayout() {
+  /**
+   * triggered by button clicker handler in ErrorFallback, to update MdLayout as the parent component of the error boundary.
+   */
+  const [trigger, setTrigger] = useState<number>(0)
+
   //TODO: see if transition causes MdLayout rerender
   const [isToneContextUpdating, startUpdateToneContext] = useTransition()
   return (
@@ -20,7 +25,10 @@ function MdLayout() {
             <FullWidthCard />
           </Grid>
           <Grid item xs={12} sm={12} md={8}>
-            <ErrorBoundary FallbackComponent={ErrorFallback}>
+            <ErrorBoundary
+              FallbackComponent={ErrorFallback}
+              onReset={() => setTrigger(trigger + 1)}
+            >
               <Suspense fallback={<MappingsFallback />}>
                 <MappingsCard />
               </Suspense>

--- a/src/components/layout/MdLayout.tsx
+++ b/src/components/layout/MdLayout.tsx
@@ -1,9 +1,10 @@
-import { Container, Grid, Skeleton } from '@mui/material'
+import { Container, Grid } from '@mui/material'
 import { Suspense, useTransition } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
 import ToneContextWrapper from '../../services/ToneContextWrapper'
 import ErrorFallback from '../err-and-feedback/ErrorFallback'
+import MappingsFallback from '../err-and-feedback/MappingsFallback'
 import FullWidthCard from '../main-view/chart/FullWidthCard'
 import MappingsCard from '../main-view/map/MappingsCard'
 import ToneCard from '../main-view/tone/ToneCard'
@@ -19,7 +20,9 @@ function MdLayout() {
             <FullWidthCard />
           </Grid>
           <Grid item xs={12} sm={12} md={8}>
-            <MappingsCard />
+            <Suspense fallback={<MappingsFallback />}>
+              <MappingsCard />
+            </Suspense>
           </Grid>
           <Grid item xs={12} sm={12} md={4}>
             <ErrorBoundary FallbackComponent={ErrorFallback}>

--- a/src/components/layout/MdLayout.tsx
+++ b/src/components/layout/MdLayout.tsx
@@ -1,4 +1,4 @@
-import { Container, Grid } from '@mui/material'
+import { Container, Grid, Skeleton } from '@mui/material'
 import { Suspense, useTransition } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
@@ -16,11 +16,7 @@ function MdLayout() {
       <ToneContextWrapper>
         <Grid container spacing={2}>
           <Grid item xs={12}>
-            <ErrorBoundary FallbackComponent={ErrorFallback}>
-              <Suspense fallback="fallback2">
-                <FullWidthCard />
-              </Suspense>
-            </ErrorBoundary>
+            <FullWidthCard />
           </Grid>
           <Grid item xs={12} sm={12} md={8}>
             <MappingsCard />

--- a/src/components/main-view/chart/FullWidthCard.tsx
+++ b/src/components/main-view/chart/FullWidthCard.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react'
-import { Grid, Paper } from '@mui/material'
+import { Grid, Paper, Skeleton } from '@mui/material'
 import { Suspense, lazy, useState, useTransition } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import useSWR from 'swr'
@@ -28,49 +28,41 @@ function FullWidthCard() {
         ${themedNeu.depressed}
       `}
     >
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
-        <Suspense fallback="fallback2">
-          <Grid
-            container
-            justifyContent={'space-between'}
-            css={
-              isUpdating
-                ? css`
-                    ${neu.pendingSection}
-                  `
-                : null
-            }
-          >
-            <Grid item xs={12} sm={12} md={3} lg={3}>
-              <ErrorBoundary fallback={<ErrorFallback error={ErrorFallback} />}>
-                <TokenCard
-                  setEndpoint={setEndpoint}
-                  startUpdate={startUpdate}
-                />
-              </ErrorBoundary>
-            </Grid>
+      <Grid
+        container
+        justifyContent={'space-between'}
+        css={
+          isUpdating
+            ? css`
+                ${neu.pendingSection}
+              `
+            : null
+        }
+      >
+        <Grid item xs={12} sm={12} md={3} lg={3}>
+          <TokenCard setEndpoint={setEndpoint} startUpdate={startUpdate} />
+        </Grid>
 
-            <Grid
-              item
-              container
-              sm={12}
-              md={9}
-              lg={9}
-              justifyContent={'center'}
+        <Grid item container sm={12} md={9} lg={9} justifyContent={'center'}>
+          <ErrorBoundary fallback={<ErrorFallback error={ErrorFallback} />}>
+            <Suspense
+              fallback={
+                <Skeleton
+                  sx={{ bgcolor: 'red' }}
+                  variant="rectangular"
+                  height={350}
+                />
+              }
             >
-              <ErrorBoundary fallback={<ErrorFallback error={ErrorFallback} />}>
-                <Suspense fallback="fallback">
-                  <ChartComponent
-                    data={data.formattedOhlc}
-                    name={data.tokenName}
-                    interval={data.interval}
-                  />
-                </Suspense>
-              </ErrorBoundary>
-            </Grid>
-          </Grid>
-        </Suspense>
-      </ErrorBoundary>
+              <ChartComponent
+                data={data.formattedOhlc}
+                name={data.tokenName}
+                interval={data.interval}
+              />
+            </Suspense>
+          </ErrorBoundary>
+        </Grid>
+      </Grid>
     </Paper>
   )
 }

--- a/src/components/main-view/chart/TokenCard.tsx
+++ b/src/components/main-view/chart/TokenCard.tsx
@@ -119,7 +119,7 @@ function TokenCard({ setEndpoint, startUpdate }: Props) {
           }}
           css={css`
             ${themedNeu.raised}
-            color: ${currentTheme.palette.primary.main}
+            color: ${currentTheme.palette.text.primary}
           `}
           onClick={(e: SyntheticEvent) =>
             startUpdate(() => {

--- a/src/components/main-view/map/MappingsCard.tsx
+++ b/src/components/main-view/map/MappingsCard.tsx
@@ -50,10 +50,11 @@ function MappingsCard(props: Props) {
   const toneContext = useToneContext()
   const currentTheme = useTheme()
   const themedNeu = currentTheme.palette.mode === 'light' ? neu.light : neu.dark
-  const { data } = useSWR(toneContext?.dispatchedEndpoint, { suspense: false })
+  const { data } = useSWR(toneContext?.dispatchedEndpoint, { suspense: true })
 
   //TODO: Gauge relative benefit of moving into a useSubmitMap hook?
   const handleSubmit = async (e: SyntheticEvent) => {
+    console.log(data)
     e.preventDefault()
     const keyMode = keyModeRef?.current?.value.split(',')
     let notesArray

--- a/src/components/main-view/map/MappingsCard.tsx
+++ b/src/components/main-view/map/MappingsCard.tsx
@@ -169,7 +169,7 @@ function MappingsCard(props: Props) {
             onClick={(e) => handleSubmit(e)}
             css={css`
               ${themedNeu.raised}
-              color: ${currentTheme.palette.primary.main}
+              color: ${currentTheme.palette.text.primary}
             `}
           >
             Submit

--- a/yarn.lock
+++ b/yarn.lock
@@ -3523,10 +3523,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.8.tgz#a051eb380a9fbcaa404550543c58e1cf5ce4ab87"
-  integrity sha512-+j2hk9BzCOrrOSJASi5XiOyBbERk9jG5O73Ya4M0env5Ixi6vUNli4qy994AINcEF+1IEHISYFfIT4zwr++LKw==
+"@types/react@18.0.9":
+  version "18.0.9"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.9.tgz#d6712a38bd6cd83469603e7359511126f122e878"
+  integrity sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
 -"Suspensified" mappingscard to synchronize state between useSwr hook in mappingscard and useSWR in chartComponent. This was primarily necessary because the current implementation relies on a shared key to synchronize the calls to useSWR, which is a string corresponding to the params on the API call that dispatched to the ToneContextWrapper and provided to the consumers of that particular context.

- changed style on two buttons because it's my party and I can style if I want to

-work on ErrorBoundaries and ErrorFallback, primarily re: triggering rerender of parent of ErrorBoundary after resetting ErrorBoundary state